### PR TITLE
node-moray#19 native-dns has broken transitive dependency on ipadder.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
 	"name": "medusa",
 	"description": "SDC Manta Interactive Session Engine",
-	"version": "0.0.3",
+	"version": "0.0.4",
 	"author": "Joyent (joyent.com)",
 	"private": true,
 	"dependencies": {
 		"assert-plus": "^1.0.0",
 		"bunyan": "^1.6.0",
 		"manta": "^2.0.5",
-		"moray": "git+https://github.com/joyent/node-moray.git#fd5781bc25a9bfe2ba82167664639753fb9f0ca5",
+		"moray": "git+https://github.com/joyent/node-moray.git#005d145f962171b8069713cce08396102573d49d",
 		"once": "1.1.1",
 		"pty.js": "0.3.0",
 		"restify": "^2.8.5",


### PR DESCRIPTION
See joyent/node-moray#19.