### PR TITLE
Reconcile mantav1 branch with master branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@
  * Copyright 2020 Joyent, Inc.
  */
 
-@Library('jenkins-joylib@v1.0.4') _
+@Library('jenkins-joylib@v1.0.6') _
 
 pipeline {
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,10 +5,10 @@
  */
 
 /*
- * Copyright 2019 Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  */
 
-@Library('jenkins-joylib@v1.0.3') _
+@Library('jenkins-joylib@v1.0.4') _
 
 pipeline {
 
@@ -19,6 +19,18 @@ pipeline {
     options {
         buildDiscarder(logRotator(numToKeepStr: '30'))
         timestamps()
+    }
+
+    parameters {
+        string(
+            name: 'AGENT_PREBUILT_AGENT_BRANCH',
+            defaultValue: '',
+            description: 'The branch to use for the agents ' +
+                'that are included in this component.<br/>' +
+                'With an empty value, the build will look for ' +
+                'agents from the same branch name as the ' +
+                'component, before falling back to "master".'
+        )
     }
 
     stages {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,10 +5,10 @@
  */
 
 /*
- * Copyright 2020 Joyent, Inc.
+ * Copyright 2021 Joyent, Inc.
  */
 
-@Library('jenkins-joylib@v1.0.6') _
+@Library('jenkins-joylib@v1.0.8') _
 
 pipeline {
 
@@ -54,7 +54,7 @@ pipeline {
 
     post {
         always {
-            joyMattermostNotification(channel: 'jenkins')
+            joySlackNotifications(channel: 'jenkins')
         }
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@
  * Copyright 2019 Joyent, Inc.
  */
 
-@Library('jenkins-joylib@v1.0.2') _
+@Library('jenkins-joylib@v1.0.3') _
 
 pipeline {
 

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
 	"name": "medusa",
 	"description": "SDC Manta Interactive Session Engine",
-	"version": "0.0.3",
+	"version": "0.0.4",
 	"author": "Joyent (joyent.com)",
 	"private": true,
 	"dependencies": {
 		"assert-plus": "^1.0.0",
 		"bunyan": "^1.6.0",
 		"manta": "^2.0.5",
-		"moray": "git+https://github.com/joyent/node-moray.git#fd5781bc25a9bfe2ba82167664639753fb9f0ca5",
+		"moray": "git+https://github.com/joyent/node-moray.git#005d145f962171b8069713cce08396102573d49d",
 		"once": "1.1.1",
 		"pty.js": "0.3.0",
 		"restify": "^2.8.5",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
 	"license": "MPL-2.0",
 	"repository": {
 		"type": "git",
-		"url": "git://github.com/joyent/manta-medusa.git"
+		"url": "https://github.com/joyent/manta-medusa.git"
 	}
 }


### PR DESCRIPTION
For #14, I applied the fix against the master branch instead of the mantav1 branch.

In addition, there's a few housekeeping commits that need to come over from master. This PR brings in the following from the master branch:

* d77b8d1 #14
* d214608 #13
* ac5ab1e #12
* d855ba0 #11
* 88fdd20 #10

Because the user tested the PR build from the master branch, and because jobs (including medusa) were dropped from mantav2 so there are no breaking changes in the master branch, it's safe to bring all of these from master into mantav1.

After this, master and mantav1 will have slightly different histories, but identical content.